### PR TITLE
chore: drop pod, namespace or node when passed as arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             target/${{ matrix.platform.target }}/release/*.tar.gz
 
   release:
-    name: Create Release, Publish Crate, and Update Homebrew
+    name: Create Release, Publish Crate, and Update Homebrew & Krew
     runs-on: ubuntu-latest
     # needs: [update_version, build]
     needs: build

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -281,9 +281,11 @@ pub fn display_pod_images(
     println!("{}", "=".repeat(80));
 
     let mut table = Table::new();
-
-    // Build the header row based on which columns to show
     let mut header_cells = Vec::new();
+
+    if show_pod {
+        header_cells.push("Pod Name");
+    }
 
     if show_node {
         header_cells.push("Node");
@@ -293,13 +295,8 @@ pub fn display_pod_images(
         header_cells.push("Namespace");
     }
 
-    if show_pod {
-        header_cells.push("Pod Name");
-    }
-
     header_cells.extend(vec!["Container", "Image Name", "Version", "Registry"]);
 
-    // Create the row from our cells
     let header_row = header_cells.into_iter().collect::<Vec<_>>();
     table.add_row(prettytable::Row::new(
         header_row.into_iter().map(prettytable::Cell::new).collect(),
@@ -311,11 +308,9 @@ pub fn display_pod_images(
         if show_pod {
             row.add_cell(prettytable::Cell::new(&image.pod_name));
         }
-
         if show_node {
             row.add_cell(prettytable::Cell::new(&image.node_name));
         }
-
         if show_namespace {
             row.add_cell(prettytable::Cell::new(&image.namespace));
         }

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -271,14 +271,19 @@ pub fn process_pod(pod: &Pod) -> Vec<PodImage> {
     pod_images
 }
 
-pub fn display_pod_images(images: &[PodImage], show_node: bool, show_namespace: bool) {
+pub fn display_pod_images(
+    images: &[PodImage],
+    show_node: bool,
+    show_namespace: bool,
+    show_pod: bool,
+) {
     println!("\n{}", "Pod Images and Registries:".green().bold());
     println!("{}", "=".repeat(80));
 
     let mut table = Table::new();
 
     // Build the header row based on which columns to show
-    let mut header_cells = vec!["Pod Name"];
+    let mut header_cells = Vec::new();
 
     if show_node {
         header_cells.push("Node");
@@ -286,6 +291,10 @@ pub fn display_pod_images(images: &[PodImage], show_node: bool, show_namespace: 
 
     if show_namespace {
         header_cells.push("Namespace");
+    }
+
+    if show_pod {
+        header_cells.push("Pod Name");
     }
 
     header_cells.extend(vec!["Container", "Image Name", "Version", "Registry"]);
@@ -297,28 +306,24 @@ pub fn display_pod_images(images: &[PodImage], show_node: bool, show_namespace: 
     ));
 
     for image in images {
-        // Create a new row for the table
         let mut row = prettytable::Row::new(Vec::new());
 
-        // Add pod name cell
-        row.add_cell(prettytable::Cell::new(&image.pod_name));
+        if show_pod {
+            row.add_cell(prettytable::Cell::new(&image.pod_name));
+        }
 
-        // Add node cell if needed
         if show_node {
             row.add_cell(prettytable::Cell::new(&image.node_name));
         }
 
-        // Add namespace cell if needed
         if show_namespace {
             row.add_cell(prettytable::Cell::new(&image.namespace));
         }
 
-        // Add container name, image name, and version
         row.add_cell(prettytable::Cell::new(&image.container_name));
         row.add_cell(prettytable::Cell::new(&image.image_name));
         row.add_cell(prettytable::Cell::new(&image.image_version));
 
-        // Add registry with yellow color
         row.add_cell(prettytable::Cell::new(&image.registry).style_spec("Fy"));
 
         table.add_row(row);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,9 @@ async fn main() -> Result<()> {
                 node,
                 pod,
             } => {
-                let show_node = node.is_none();
-                let show_namespace = node.is_some() && namespace == "default";
-                let show_pod = pod.is_none();
+                let _show_node = node.is_none();
+                let _show_namespace = node.is_some() && namespace == "default";
+                let _show_pod = pod.is_none();
 
                 match client
                     .get_pod_images(&namespace, node.as_deref(), pod.as_deref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ async fn main() -> Result<()> {
                 node,
                 pod,
             } => {
+                let show_node = node.is_none();
+                let show_namespace = node.is_some() && namespace == "default";
+                let show_pod = pod.is_none();
+
                 match client
                     .get_pod_images(&namespace, node.as_deref(), pod.as_deref())
                     .await
@@ -51,9 +55,16 @@ async fn main() -> Result<()> {
                                 "\n{}",
                                 "No pod images found matching your criteria.".yellow()
                             );
+                        } else if node.is_some() && pod.is_some() && namespace != "default" {
+                            display_pod_images(&pod_images, false, false, false);
                         } else {
+                            // Hide columns that are passed as arguments
                             let show_node = node.is_none();
-                            let show_namespace = node.is_none();
+
+                            // Only hide namespace if explicitly set to non-default
+                            let explicit_namespace_set = namespace != "default";
+                            let show_namespace = !explicit_namespace_set;
+
                             let show_pod = pod.is_none();
 
                             display_pod_images(&pod_images, show_node, show_namespace, show_pod);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,11 @@ async fn main() -> Result<()> {
                                 "No pod images found matching your criteria.".yellow()
                             );
                         } else {
-                            let show_namespace = node.is_some();
                             let show_node = node.is_none();
+                            let show_namespace = node.is_none();
+                            let show_pod = pod.is_none();
 
-                            display_pod_images(&pod_images, show_node, show_namespace);
+                            display_pod_images(&pod_images, show_node, show_namespace, show_pod);
                         }
                     }
                     Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ async fn main() -> Result<()> {
                                 "No pod images found matching your criteria.".yellow()
                             );
                         } else {
-                            display_pod_images(&pod_images, node.is_some());
+                            let show_namespace = node.is_some();
+
+                            display_pod_images(&pod_images, node.is_some(), show_namespace);
                         }
                     }
                     Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,9 @@ async fn main() -> Result<()> {
                             );
                         } else {
                             let show_namespace = node.is_some();
+                            let show_node = node.is_none();
 
-                            display_pod_images(&pod_images, node.is_some(), show_namespace);
+                            display_pod_images(&pod_images, show_node, show_namespace);
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
- This allows the UI to be more focused and clean